### PR TITLE
Simple replace for domain name in emails

### DIFF
--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -185,14 +185,10 @@ module Database
     end
 
     def remove_sensitive_data
-      puts "Local database: remove sensitive data"
-
-      schemas = %w(public lab us abstract)
-      schemas.each do |schema|
-        puts "Local database: removing sensitive data from schema #{schema}"
-        email_update_sql = "UPDATE #{schema}.users SET email = CONCAT(SUBSTRING(email from '^[\\w.+\\-\\_\\~\\d]+'), '@bogus.ams-ix.net') WHERE email not like '%ams-ix.net';"
-        execute("#{pgpass} psql -d #{database} #{credentials} -c \"#{email_update_sql}\"")
-      end
+      puts "Local database: removing sensitive data, hold tight..."
+      stdout3, status3 = Open3.capture2('bundle', 'exec', 'rake', 'replace_emails_in_database')
+      puts stdout3
+      puts status3
     end
 
     private

--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -190,7 +190,7 @@ module Database
       schemas = %w(public lab us abstract)
       schemas.each do |schema|
         puts "Local database: removing sensitive data from schema #{schema}"
-        email_update_sql = "UPDATE #{schema}.users SET email = CONCAT(SUBSTRING(email from '^[\\w.+\\-\\_\\~\\d]+'), '@bogus.ams-ix.net');"
+        email_update_sql = "UPDATE #{schema}.users SET email = CONCAT(SUBSTRING(email from '^[\\w.+\\-\\_\\~\\d]+'), '@bogus.ams-ix.net') WHERE email not like '%ams-ix.net';"
         execute("#{pgpass} psql -d #{database} #{credentials} -c \"#{email_update_sql}\"")
       end
     end

--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -184,11 +184,18 @@ module Database
       @cap.upload! output_file, remote_file
     end
 
-    def remove_sensitive_data
+    def remove_sensitive_data(schemas)
+      # Accepts a list of schemas, for example [nl:us]
+      # meaning "replace emails for shards nl and us"
+
+      schemas = [schemas] unless schemas.is_a? Array
+
       puts "Local database: removing sensitive data, hold tight..."
-      stdout3, status3 = Open3.capture2('bundle', 'exec', 'rake', 'replace_emails_in_database')
-      puts stdout3
-      puts status3
+      for schema in schemas do
+        stdout3, status3 = Open3.capture2('bundle', 'exec', 'rake', "replace_emails_in_database[#{schema}]")
+        puts stdout3
+        puts status3
+      end
     end
 
     private

--- a/lib/capistrano-db-tasks/database.rb
+++ b/lib/capistrano-db-tasks/database.rb
@@ -184,6 +184,17 @@ module Database
       @cap.upload! output_file, remote_file
     end
 
+    def remove_sensitive_data
+      puts "Local database: remove sensitive data"
+
+      schemas = %w(public lab us abstract)
+      schemas.each do |schema|
+        puts "Local database: removing sensitive data from schema #{schema}"
+        email_update_sql = "UPDATE #{schema}.users SET email = CONCAT(SUBSTRING(email from '^[\\w.+\\-\\_\\~\\d]+'), '@bogus.ams-ix.net');"
+        execute("#{pgpass} psql -d #{database} #{credentials} -c \"#{email_update_sql}\"")
+      end
+    end
+
     private
 
     def execute(cmd)

--- a/lib/capistrano-db-tasks/dbtasks.rb
+++ b/lib/capistrano-db-tasks/dbtasks.rb
@@ -39,7 +39,7 @@ namespace :db do
         puts "Local database: #{Database::Local.new(self).database}"
         if fetch(:skip_data_sync_confirm) || Util.prompt('Are you sure you want to erase your local database with server database')
           Database.remote_to_local(self)
-          Database::Local.new(self).remove_sensitive_data
+          Database::Local.new(self).remove_sensitive_data('nl')
         end
       end
     end
@@ -50,6 +50,7 @@ namespace :db do
         puts "Local database: #{Database::Local.new(self).database}"
         if fetch(:skip_data_sync_confirm) || Util.prompt('Are you sure you want to erase your local database with server database')
           Database.selective_schemas_to_local(self, args[:schemas].split(':'))
+          Database::Local.new(self).remove_sensitive_data(args[:schemas].split(':'))
         end
       end    
     end

--- a/lib/capistrano-db-tasks/dbtasks.rb
+++ b/lib/capistrano-db-tasks/dbtasks.rb
@@ -39,6 +39,7 @@ namespace :db do
         puts "Local database: #{Database::Local.new(self).database}"
         if fetch(:skip_data_sync_confirm) || Util.prompt('Are you sure you want to erase your local database with server database')
           Database.remote_to_local(self)
+          Database::Local.new(self).remove_sensitive_data
         end
       end
     end


### PR DESCRIPTION
Every time we do a

`bundle exec cap production db:pull`

e-mail addresses of all users in users table will have domain name changed to `bogus.ams-ix.net`. For example

```
151,"bastiaan","bastiaan@bogus.ams-ix.net"
238,"alex.bik","alex@bogus.ams-ix.net"
141,"rydlichowski.piotr","prydlich@bogus.ams-ix.net"
814,"steven","steven.bakker@bogus.ams-ix.net"
847,"bzimmermann","Bjoern.Zimmermann@bogus.ams-ix.net"
850,"asgcnet.noc","noc@bogus.ams-ix.net"
821,"henk","henk@bogus.ams-ix.net"
295,"m.ooms@nedzone.nl","m.ooms@bogus.ams-ix.net"
192,"finance","finance@bogus.ams-ix.net"
390,"marek.bazyly","bazyly@bogus.ams-ix.net"
950,"tomasz.szewczyk","tomeks@bogus.ams-ix.net"
100,"arien","arien.vijn@bogus.ams-ix.net"
```

In terminal output if will look close to this

```
~/p/my-ams-ix ❯❯❯ bundle exec cap production db:pull
Using airbrussh format.
Verbose output is being written to log/capistrano.log.
Local database: myamsix_returns_development
Please enter answer (Are you sure you want to erase your local database with server database (y)es, (n)o  ? ): y
Local database: remove sensitive data
Local database: removing sensitive data from schema public
UPDATE 3347
Local database: removing sensitive data from schema lab
UPDATE 49
Local database: removing sensitive data from schema us
UPDATE 269
```

@webdevs please tell me what you think. "Like" / "don't like" will do, open for suggestions.
